### PR TITLE
fixed incorrect formatting

### DIFF
--- a/src/api/src/main.py
+++ b/src/api/src/main.py
@@ -34,7 +34,7 @@ async def download_book(
     if username and not password or password and not username:
         return HTMLResponse(
             status_code=422,
-            content='Include both the username _and_ password, or neither. Support is available on the <a href="https://discord.gg/P9RHC4KCwd" target="_blank">Discord</a>',
+            content='Include both the username <u>and</u> password, or neither. Support is available on the <a href="https://discord.gg/P9RHC4KCwd" target="_blank">Discord</a>',
         )
 
     if username and password:


### PR DESCRIPTION
The error screen for inputting only a username or a password (not both) has some incorrect formatting, the "and" displays as `_and_`. I assume this is a mistake and the "and" was supposed to be underlined.