### PR TITLE
Add URI encoding to credentials

### DIFF
--- a/src/api/src/main.py
+++ b/src/api/src/main.py
@@ -38,6 +38,7 @@ async def download_book(
         )
 
     if username and password:
+        # username and password are URL-Encoded by the frontend. FastAPI automatically decodes them.
         try:
             cookies = await wp_get_cookies(username=username, password=password)
         except ValueError:

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -19,7 +19,7 @@
     `/download/${story_id}?om=1` +
     (download_images ? "&download_images=true" : "") +
     (is_paid_story
-      ? `&username=${credentials.username}&password=${credentials.password}`
+      ? `&username=${encodeURIComponent(credentials.username)}&password=${encodeURIComponent(credentials.password)}`
       : "");
 </script>
 


### PR DESCRIPTION
This fixes the issue I was having where characters like `#` and `&` weren't getting interpreted properly. Weirdly enough, it doesn't need decoding in the API... nor does it look like it's getting encoded in the first place. The hover-link I see when I hover on the "Download" button shows my unencoded credentials, but it does work now.