### PR TITLE
Made "Download More" button work

### DIFF
--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -194,7 +194,10 @@
               >, where we release features early and discuss updates.
             </p>
           </div>
-          <a href="/" class="btn btn-outline btn-lg mt-10">Download More</a>
+          <a
+            on:click={() => (window.location.href = window.location.href)}
+            class="btn btn-outline btn-lg mt-10">Download More</a
+          >
         </div>
       {/if}
     </div>

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -49,6 +49,13 @@
       raw_story_id = story_id;
     }
   }
+
+  function reset() {
+    after_download_page = false;
+    story_id = "";
+    raw_story_id = "";
+    is_paid_story = false;
+  }
 </script>
 
 <div>
@@ -194,7 +201,9 @@
               >, where we release features early and discuss updates.
             </p>
           </div>
-          <a href="/" class="btn btn-outline btn-lg mt-10">Download More</a>
+          <a on:click={() => reset()} class="btn btn-outline btn-lg mt-10"
+            >Download More</a
+          >
         </div>
       {/if}
     </div>

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -49,13 +49,6 @@
       raw_story_id = story_id;
     }
   }
-
-  function reset() {
-    after_download_page = false;
-    story_id = "";
-    raw_story_id = "";
-    is_paid_story = false;
-  }
 </script>
 
 <div>
@@ -201,8 +194,12 @@
               >, where we release features early and discuss updates.
             </p>
           </div>
-          <a on:click={() => reset()} class="btn btn-outline btn-lg mt-10"
-            >Download More</a
+          <button
+            on:click={() => {
+              after_download_page = false;
+              raw_story_id = "";
+            }}
+            class="btn btn-outline btn-lg mt-10">Download More</button
           >
         </div>
       {/if}

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -194,10 +194,7 @@
               >, where we release features early and discuss updates.
             </p>
           </div>
-          <a
-            on:click={() => (window.location.href = window.location.href)}
-            class="btn btn-outline btn-lg mt-10">Download More</a
-          >
+          <a href="/" class="btn btn-outline btn-lg mt-10">Download More</a>
         </div>
       {/if}
     </div>


### PR DESCRIPTION
The "Download More" button that is displayed after the user downloads a book does not work. `href="/"` doesn't reload the page because the user is already on it. This commit forces the page to reload, correctly returning the user to the download page.