### PR TITLE
fix(frontend): Remove deprecated feedback button

### DIFF
--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -200,12 +200,6 @@
               </label>
             </div>
           </form>
-
-          <button
-            data-feedback-fish
-            class="link pb-4"
-            data-umami-event="Feedback">Feedback</button
-          >
         </div>
       {:else}
         <div class="text-center max-w-4xl">


### PR DESCRIPTION
[fix(frontend): Remove feedbackfish script](https://github.com/TheOnlyWayUp/WattpadDownloader/commit/9d7464b461db3c8c4f1871fc72b4fd1f7d0774ee) removes the Feedback Fish script, but the button that it used to connect to was never removed.