### PR TITLE
fix(api): Fix PDF ToC page number formatting

### DIFF
--- a/src/api/src/pdf/stylesheet.css
+++ b/src/api/src/pdf/stylesheet.css
@@ -205,6 +205,8 @@ section {
 #contents a {
   color: inherit;
   text-decoration: none;
+  display: flex;
+  justify-content: space-between;
 }
 #contents a::before {
   content: target-counter(attr(href), h2-counter) '. ' target-text(attr(href));


### PR DESCRIPTION
Fixes #34. This does not fix the weird multiple links issue.
![image](https://github.com/user-attachments/assets/9caa2664-eff8-4e01-ac7e-bd6a781142a2)
