### PR TITLE
feat(frontend): Added nice-looking download format slider

### DIFF
--- a/src/frontend/src/app.pcss
+++ b/src/frontend/src/app.pcss
@@ -2,3 +2,63 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+.switch {
+position: relative;
+display: inline-block;
+width: 40px;
+height: 21px;
+}
+
+.switch input {
+opacity: 0;
+width: 0;
+height: 0;
+margin-left: auto;
+}
+
+.slider {
+position: absolute;
+cursor: pointer;
+top: 0;
+left: 0;
+right: 0;
+bottom: 0;
+background-color: #ffd900;
+-webkit-transition: 0.4s;
+transition: 0.4s;
+}
+
+.slider:before {
+position: absolute;
+content: "";
+height: 15px;
+width: 16px;
+left: 4px;
+bottom: 3px;
+background-color: white;
+-webkit-transition: 0.4s;
+transition: 0.4s;
+}
+
+input:checked + .slider {
+background-color: #ffa400;
+}
+
+input:focus + .slider {
+box-shadow: 0 0 1px #2196f3;
+}
+
+input:checked + .slider:before {
+-webkit-transform: translateX(16px);
+-ms-transform: translateX(16px);
+transform: translateX(16px);
+}
+
+/* Rounded sliders */
+.slider.round {
+border-radius: 34px;
+}
+
+.slider.round:before {
+border-radius: 50%;
+}

--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -202,7 +202,6 @@
                 </label>
               {/if}
             </div>
-
             <div class="form-control mt-6">
               <a
                 class="btn rounded-l-none"
@@ -213,17 +212,22 @@
                 href={url}
                 on:click={() => (after_download_page = true)}>Download</a
               >
-
-              <label class="swap w-fit label mt-2">
-                <input type="checkbox" bind:checked={download_as_pdf} />
-                <div class="swap-on">
-                  Downloading as <span class=" underline text-bold">PDF</span> (Click)
-                </div>
-                <div class="swap-off">
-                  Downloading as <span class=" underline text-bold">EPUB</span> (Click)
-                </div>
-              </label>
-
+              <span></span>
+              <span style="display: flex; justify-content: space-between; align-items: center;">
+                <span>
+                  Downloading as 
+                  <span
+                    class="underline text-bold"
+                    style="display: inline-block; padding-top: 10px;"
+                  >
+                    {#if download_as_pdf}PDF{:else}EPUB{/if}
+                  </span>
+                </span>
+                <label class="switch">
+                  <input type="checkbox" bind:checked={download_as_pdf} />
+                  <span class="slider round"></span>
+                </label>
+              </span>                         
               <label class="cursor-pointer label">
                 <span class="label-text"
                   >Include Images (<strong>Slower Download</strong>)</span


### PR DESCRIPTION
Adds a nice-looking slider that replaces the "(Click)" to toggle the download format

![Screenshot from 2025-01-06 21-36-32](https://github.com/user-attachments/assets/f80bfdfc-06f3-4480-8edd-89453e3bf629)
![Screenshot from 2025-01-06 21-36-42](https://github.com/user-attachments/assets/618d1339-8159-4226-840e-facf2cfff930)
