### PR TITLE
fix(api): Carry over paragraph styling

### DIFF
--- a/src/api/src/create_book.py
+++ b/src/api/src/create_book.py
@@ -152,6 +152,10 @@ def generate_clean_part_html(part: Part, content: str) -> bs4.Tag:
 
     for child in html.find_all("p"):
         current_paragraph = clean.new_tag("p")
+
+        # Attempt to carry over paragraph styling
+        current_paragraph["style"] = child.get("style", "text-align: left;")
+
         for p_child in list(child.children):
             if not p_child:
                 continue


### PR DESCRIPTION
This fixes #38. Again. This commit never got merged into `scuffed-normie-version`, only `feature/#29-pdf-downloads`, so now it isn't in `master`.