### PR TITLE
docker: Fix .dockerignore uv.lock entry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,4 @@ build
 .env
 *log
 *.md
-uv.lock
+src/api/uv.lock


### PR DESCRIPTION
Fixes `.dockerignore` to actually ignore `src/api/uv.lock`.